### PR TITLE
fix: wrong behaviour CTRL-\(SIGQUIT) moves cursor to begin of line

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -4,10 +4,12 @@
 #include <readline/history.h>
 #include <libft.h>
 
-void	sigint_h(int sig)
+// handler for SIGQUIT signal (CTRL-C)
+// creates new prompt on next line
+static void	sigint_handler(int sig)
 {
 	(void)sig;
-	printf("\n");
+	ft_putchar_fd('\n', STDOUT_FILENO);
 	rl_on_new_line();
 	rl_replace_line("", 0);
 	rl_redisplay();
@@ -15,6 +17,6 @@ void	sigint_h(int sig)
 
 void	init_signals(void)
 {
-	signal(SIGINT, sigint_h);
+	signal(SIGINT, sigint_handler);
 	signal(SIGQUIT, SIG_IGN);
 }

--- a/src/signals.c
+++ b/src/signals.c
@@ -13,14 +13,8 @@ void	sigint_h(int sig)
 	rl_redisplay();
 }
 
-void	sigquit_h(int sig)
-{
-	(void)sig;
-	ft_putstr_fd("\b\b  \b\b", STDOUT_FILENO);
-}
-
 void	init_signals(void)
 {
 	signal(SIGINT, sigint_h);
-	signal(SIGQUIT, sigquit_h);
+	signal(SIGQUIT, SIG_IGN);
 }


### PR DESCRIPTION
- improve code readability